### PR TITLE
Fix some button issues on touchscreens

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -44,7 +44,7 @@ main {
   display: inline-block;
   font-size: .9rem;
   outline: none;
-  padding: 2px 12px;
+  padding: 4px 16px;
   position: relative;
   top: 1px;
 }
@@ -60,7 +60,8 @@ main {
 
 .answer-btn {
   display:block;
-  margin: 1px;
+  margin: 4px 0;
+  padding-left: 10px;
 }
 
 #final-score {
@@ -97,5 +98,13 @@ main {
   main {
     width: 60%;
     max-width: 600px;
-  }  
+  }
+
+  .btn {
+    padding: 2px 12px 2px 10px;
+  }
+
+  .answer-btn {
+    margin: 1px;
+  }
 }

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -180,9 +180,6 @@ var showNextQuestion = function() {
   } else {
     endQuiz();
   }
-
-  // to prevent lingering hover on touchscreens
-  resultEl.focus({preventScroll:true});
 };
 
 var endQuiz = function() {
@@ -306,6 +303,17 @@ var clearHighScoresHandler = function(event) {
   showHighScores();
 };
 
+// disable hover effect for buttons on touchscreens
+var disableHover = function(event) {
+  var touchStyleEl = document.createElement('style');
+  touchStyleEl.setAttribute('type', 'text/css');
+  touchStyleEl.textContent = ".btn:hover { background: rgb(83, 11, 116); }";
+  document.querySelector('#main-content').insertBefore(touchStyleEl, welcomeEl);
+  console.log(this);
+  console.log(document.querySelector('#main-content'));
+  console.log(touchStyleEl);
+}
+
 // event listeners
 viewHighScoresEl.addEventListener('click', viewHighScoresHandler);
 startQuizEl.addEventListener('click', startQuizHandler);
@@ -313,6 +321,9 @@ saveScoreEl.addEventListener('click', saveHighScoreHandler);
 clearHighScoresButtonEl.addEventListener('click', clearHighScoresHandler);
 goBackButtonEl.addEventListener('click', initQuiz);
 tryAgainButtonEl.addEventListener('click', initQuiz);
+
+// detect if using touch
+startQuizEl.addEventListener('touchstart', disableHover, { passive: true, once: true });
 
 
 // start the app on load


### PR DESCRIPTION
Increase margin and padding on buttons on touchscreens to help avoid errant button presses.  Remove the button highlight effect on hover, because the last touch location seems to hang around as a hover after the screen content changes.